### PR TITLE
Use clojure.tools.namespace.repl/refresh-all to reload code

### DIFF
--- a/lein-virgil/src/lein_virgil/plugin.clj
+++ b/lein-virgil/src/lein_virgil/plugin.clj
@@ -4,8 +4,8 @@
 
 (defn middleware [project]
   (if (contains? project :java-source-paths)
-    (let [project' (-> project
-                     (update-in [:dependencies] conj '[virgil "0.1.5"] '[org.ow2.asm/asm "5.1"])
+    (let [dependencies '[[virgil "0.1.5"] [org.ow2.asm/asm "5.1"] [org.clojure/tools.namespace "0.2.11"]]
+          project' (-> project (update-in [:dependencies] into dependencies)
                      (update-in [:injections] concat `((require 'virgil) (virgil/watch ~@(:java-source-paths project)))))]
       project')
     project))

--- a/project.clj
+++ b/project.clj
@@ -2,4 +2,5 @@
   :license {:name "MIT License"}
   :dependencies []
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
+                                  [org.clojure/tools.namespace "0.2.11"]
                                   [org.ow2.asm/asm "5.1"]]}})

--- a/src/virgil.clj
+++ b/src/virgil.clj
@@ -1,6 +1,7 @@
 (ns virgil
   (:require
    [clojure.java.io :as io]
+   [clojure.tools.namespace.repl :refer (refresh-all)]
    [virgil.watch :refer (watch-directory)]
    [virgil.compile :refer (compile-all-java)]))
 
@@ -13,11 +14,10 @@
         (let [recompile (fn []
                           (println (str "\nrecompiling all files in " d))
                           (compile-all-java d)
-                          (doseq [ns (all-ns)]
-                            (try
-                              (require (symbol (str ns)) :reload)
-                              (catch Throwable e
-                                ))))]
+                          ;; We need to create a thread binding for *ns* so that
+                          ;; refresh-all can use in-ns.
+                          (binding [*ns* *ns*]
+                            (refresh-all)))]
           (swap! watches conj prefix)
           (watch-directory (io/file d)
             (fn [f]

--- a/test/virgil_test.clj
+++ b/test/virgil_test.clj
@@ -2,8 +2,12 @@
   (:require
    [clojure.java.io :as io]
    [clojure.java.shell :as sh]
-   [virgil :as v]
-   [clojure.test :refer :all]))
+   [virgil]
+   [clojure.test :refer :all]
+   [clojure.tools.namespace.repl :refer [disable-unload!]]))
+
+;; Unloading this namespace while test-watch is running breaks the test.
+(disable-unload!)
 
 (defn magic-number []
   (let [cl (clojure.lang.RT/makeClassLoader)


### PR DESCRIPTION
This is to address issue #8: it ensures that the namespaces are reloaded in the dependency order.