### PR TITLE
Allow windows path separator chars

### DIFF
--- a/src/virgil/compile.clj
+++ b/src/virgil/compile.clj
@@ -94,7 +94,7 @@
   (let [path (str f)]
     (when (.endsWith path ".java")
       (let [path' (.substring path (count prefix) (- (count path) 5))]
-        (->> (str/split path' #"/")
+        (->> (str/split path' #"/|\\")
           (remove empty?)
           (interpose ".")
           (apply str))))))


### PR DESCRIPTION
This change is needed so virgil is able to correctly convert windows paths to class names.