### PR TITLE
Skip any .#SomeFile.java from the action

### DIFF
--- a/src/virgil.clj
+++ b/src/virgil.clj
@@ -3,7 +3,7 @@
    [clojure.java.io :as io]
    [clojure.tools.namespace.repl :refer (refresh-all)]
    [virgil.watch :refer (watch-directory)]
-   [virgil.compile :refer (compile-all-java)]))
+   [virgil.compile :refer (compile-all-java java-file?)]))
 
 (def watches (atom #{}))
 
@@ -21,7 +21,6 @@
           (swap! watches conj prefix)
           (watch-directory (io/file d)
             (fn [f]
-              (when (and (.endsWith (str f) ".java")
-                      (not (.contains (str f) "#")))
+              (when (java-file? (str f))
                 (recompile))))
           (recompile))))))

--- a/src/virgil.clj
+++ b/src/virgil.clj
@@ -22,6 +22,6 @@
           (watch-directory (io/file d)
             (fn [f]
               (when (and (.endsWith (str f) ".java")
-                      (not (.contains (str f) ".#")))
+                      (not (.contains (str f) "#")))
                 (recompile))))
           (recompile))))))

--- a/src/virgil.clj
+++ b/src/virgil.clj
@@ -21,6 +21,7 @@
           (swap! watches conj prefix)
           (watch-directory (io/file d)
             (fn [f]
-              (when (.endsWith (str f) ".java")
+              (when (and (.endsWith (str f) ".java")
+                      (not (.contains (str f) ".#")))
                 (recompile))))
           (recompile))))))

--- a/src/virgil/compile.clj
+++ b/src/virgil/compile.clj
@@ -93,7 +93,7 @@
 (defn file->class [^String prefix ^File f]
   (let [path (str f)]
     (when (and (.endsWith path ".java")
-            (not (.contains path ".#")))
+            (not (.contains path "#")))
       (let [path' (.substring path (count prefix) (- (count path) 5))]
         (->> (str/split path' #"/|\\")
           (remove empty?)

--- a/src/virgil/compile.clj
+++ b/src/virgil/compile.clj
@@ -92,7 +92,8 @@
 
 (defn file->class [^String prefix ^File f]
   (let [path (str f)]
-    (when (.endsWith path ".java")
+    (when (and (.endsWith path ".java")
+            (not (.contains path ".#")))
       (let [path' (.substring path (count prefix) (- (count path) 5))]
         (->> (str/split path' #"/|\\")
           (remove empty?)

--- a/src/virgil/compile.clj
+++ b/src/virgil/compile.clj
@@ -90,10 +90,16 @@
 
       class->bytecode)))
 
+(defn java-file?
+  [path]
+  (let [base-name (io/file path)]
+    (and
+      (.endsWith (.getName base-name) ".java")
+      (not (.startsWith (.getName base-name) ".#")))))
+
 (defn file->class [^String prefix ^File f]
   (let [path (str f)]
-    (when (and (.endsWith path ".java")
-            (not (.contains path "#")))
+    (when (java-file? path)
       (let [path' (.substring path (count prefix) (- (count path) 5))]
         (->> (str/split path' #"/|\\")
           (remove empty?)


### PR DESCRIPTION
Hi @ztellman 

Thanks for the great project. I found that for some reason I keep getting the error when trying to reload the code locally. It seems that virgil will some how find the file `.#JavaFile.java` when I am editing/changing the `JavaFile.java`. This PR is trying to skip this type of files and allow virgil to run properly.

I can consistently replicate it in my two Arch Linux machine so I guess someone else may be encounter the same issue.

I am using Emacs and on the REPL I got something like this when trying this with my simple project [try-virgil](https://github.com/agilecreativity/try-virgil)

```
recompiling all files in /home/bchoomnuan/projects/personal/try-virgil/src/main/java
/home/bchoomnuan/projects/personal/try-virgil/src/main/java/try_virgil/.#SimpleLib.java (No such file or directory)
try_virgil.core> 
```