### PR TITLE
fix handling of URIs on windows

### DIFF
--- a/src/virgil/compile.clj
+++ b/src/virgil/compile.clj
@@ -30,8 +30,8 @@
 (defn source-object
   [class-name source]
   (proxy [SimpleJavaFileObject]
-      [(java.net.URI/create (str "string://" File/separator
-                                 (.replace ^String class-name "." File/separator)
+      [(java.net.URI/create (str "string:///"
+                                 (.replace ^String class-name "." "/")
                                  (. JavaFileObject$Kind/SOURCE extension)))
        JavaFileObject$Kind/SOURCE]
       (getCharContent [_] source)))
@@ -40,8 +40,8 @@
   "Returns a JavaFileObject to store a class file's bytecode."
   [class-name baos]
   (proxy [SimpleJavaFileObject]
-      [(java.net.URI/create (str "string://" File/separator
-                                 (.replace ^String class-name "." File/separator)
+      [(java.net.URI/create (str "string:///"
+                                 (.replace ^String class-name "." "/")
                                  (. JavaFileObject$Kind/CLASS extension)))
        JavaFileObject$Kind/CLASS]
     (openOutputStream [] baos)))


### PR DESCRIPTION
use slash character when building URIs.

virgil.compile did use File/Separator as a separator for URIs. On Windows
File/Separator is backslash "\" and java.net.URI/create can't handle that.

This is the backtrace I got with the old code on windows:

,----
| recompiling all files in ["C:\\Users\\ralf\\JavaRechenkern\\src"]
| Exception in thread "main" java.lang.IllegalArgumentException: Illegal character in authority at index 9: string://\RiskEngine\Marktdaten\MarketSzenarios.java, compiling:(C:\Users\ralf\AppData\Local\Temp\2\form-init1564154278924883911.clj:1:110)
|         at clojure.lang.Compiler.load(Compiler.java:7391)
|         at clojure.lang.Compiler.loadFile(Compiler.java:7317)
|         at clojure.main$load_script.invokeStatic(main.clj:275)
|         at clojure.main$init_opt.invokeStatic(main.clj:277)
|         at clojure.main$init_opt.invoke(main.clj:277)
|         at clojure.main$initialize.invokeStatic(main.clj:308)
|         at clojure.main$null_opt.invokeStatic(main.clj:342)
|         at clojure.main$null_opt.invoke(main.clj:339)
|         at clojure.main$main.invokeStatic(main.clj:421)
|         at clojure.main$main.doInvoke(main.clj:384)
|         at clojure.lang.RestFn.invoke(RestFn.java:421)
|         at clojure.lang.Var.invoke(Var.java:383)
|         at clojure.lang.AFn.applyToHelper(AFn.java:156)
|         at clojure.lang.Var.applyTo(Var.java:700)
|         at clojure.main.main(main.java:37)
| Caused by: java.lang.IllegalArgumentException: Illegal character in authority at index 9: string://\RiskEngine\Marktdaten\MarketSzenarios.java
|         at java.net.URI.create(URI.java:852)
|         at virgil.compile$source_object.invokeStatic(compile.clj:33)
|         at virgil.compile$source_object.invoke(compile.clj:30)
|         at virgil.compile$source__GT_bytecode$fn__17858.invoke(compile.clj:68)
`----

With that change it looks like virgil runs on Windows; at least I haven't run
into other problems yet.