### PR TITLE
run the first recompile synchronously

### DIFF
--- a/src/virgil.clj
+++ b/src/virgil.clj
@@ -46,16 +46,16 @@
                     ;; refresh-all can use in-ns.
                     (binding [*ns* *ns*]
                       (refresh-all)))
-        recompile (make-idle-callback recompile 100)]
+        schedule-recompile (make-idle-callback recompile 100)]
 
     (doseq [d directories]
       (let [prefix (.getCanonicalPath (io/file d))]
-        (recompile)
+        (schedule-recompile)
         (when-not (contains? @watches prefix)
           (swap! watches conj prefix)
           (watch-directory (io/file d)
             (fn [f]
               (when (java-file? (str f))
-                (recompile)))))))
+                (schedule-recompile)))))))
 
     (recompile)))


### PR DESCRIPTION
The jsonista project is using virgil when running tests.

Make sure the first recompilation is done, before giving control back from virgil.

fixes issue #15