### PR TITLE
Have compile-all-java return class->bytecode map

### DIFF
--- a/src/virgil/compile.clj
+++ b/src/virgil/compile.clj
@@ -157,6 +157,7 @@
                                   (map #(vector (file->class d %) %)))))
                           (remove #(-> % first nil?))
                           (map (fn [[c f]] [c (slurp f)]))
-                          (into {}))]
-    (compile-java nil diag name->source)
-    (print-diagnostics diag)))
+                          (into {}))
+        class->bytecode (compile-java nil diag name->source)]
+    (print-diagnostics diag)
+    class->bytecode))


### PR DESCRIPTION
I was working on #22 and realized that #23 changed the return value for `compile-all-java`.  It previously returned a map of class->bytecode.  This updates it to return the map like it used to.