### PR TITLE
Raise asm version to fix IllegalArgumentException in asm's ClassReader.

### DIFF
--- a/lein-virgil/project.clj
+++ b/lein-virgil/project.clj
@@ -1,3 +1,3 @@
-(defproject lein-virgil "0.1.8"
+(defproject lein-virgil "0.1.9-SNAPSHOT"
   :license {:name "MIT License"}
   :eval-in-leiningen true)

--- a/lein-virgil/src/lein_virgil/plugin.clj
+++ b/lein-virgil/src/lein_virgil/plugin.clj
@@ -3,8 +3,8 @@
    [leiningen.core.eval :as eval]))
 
 (def overwrites
-  '[[virgil "0.1.8"]
-    [org.ow2.asm/asm "6.0"]
+  '[[virgil "0.1.9-SNAPSHOT"]
+    [org.ow2.asm/asm "6.2.1"]
     [org.clojure/tools.namespace "0.2.11"]])
 
 (defn overwrite-dependencies [deps overwrites]


### PR DESCRIPTION
Here's the full exception I got with the previous version (6.0):
```
recompiling all files in
["/xxx/src/java"
"/xxx/src/generated"]
nil
Exception in thread "main" java.lang.IllegalArgumentException,
compiling:(/private/var/folders/hn/tgwyrdmj1tb5pmmbdkd1g_qc0000gn/T/form-init993856113380221424.clj:1:124)
    at clojure.lang.Compiler.load(Compiler.java:7526)
    at clojure.lang.Compiler.loadFile(Compiler.java:7452)
    at clojure.main$load_script.invokeStatic(main.clj:278)
    at clojure.main$init_opt.invokeStatic(main.clj:280)
    at clojure.main$init_opt.invoke(main.clj:280)
    at clojure.main$initialize.invokeStatic(main.clj:311)
    at clojure.main$null_opt.invokeStatic(main.clj:345)
    at clojure.main$null_opt.invoke(main.clj:342)
    at clojure.main$main.invokeStatic(main.clj:424)
    at clojure.main$main.doInvoke(main.clj:387)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.lang.Var.applyTo(Var.java:702)
    at clojure.main.main(main.java:37)
Caused by: java.lang.IllegalArgumentException
    at org.objectweb.asm.ClassReader.<init>(ClassReader.java:160)
    at org.objectweb.asm.ClassReader.<init>(ClassReader.java:143)
    at virgil.decompile$parents.invokeStatic(decompile.clj:12)
    at virgil.decompile$parents.invoke(decompile.clj:12)
    at
virgil.decompile$rank_order$parents__10188.invoke(decompile.clj:24)
    at clojure.core$map$fn__5587.invoke(core.clj:2747)
    at clojure.lang.LazySeq.sval(LazySeq.java:40)
    at clojure.lang.LazySeq.seq(LazySeq.java:49)
    at clojure.lang.RT.seq(RT.java:528)
    at clojure.core$seq__5124.invokeStatic(core.clj:137)
    at clojure.core$zipmap.invokeStatic(core.clj:3063)
    at clojure.core$zipmap.invoke(core.clj:3063)
    at virgil.decompile$rank_order.invokeStatic(decompile.clj:25)
    at virgil.decompile$rank_order.invoke(decompile.clj:18)
    at virgil.compile$compile_java.invokeStatic(compile.clj:124)
    at virgil.compile$compile_java.invoke(compile.clj:119)
    at virgil.compile$compile_all_java.invokeStatic(compile.clj:161)
    at virgil.compile$compile_all_java.invoke(compile.clj:149)
    at virgil$watch$recompile__10314.invoke(virgil.clj:44)
    at virgil$watch.invokeStatic(virgil.clj:61)
    at virgil$watch.doInvoke(virgil.clj:41)
    at clojure.lang.RestFn.invoke(RestFn.java:421)
    at user$eval10327.invokeStatic(form-init993856113380221424.clj:1)
    at user$eval10327.invoke(form-init993856113380221424.clj:1)
    at clojure.lang.Compiler.eval(Compiler.java:7062)
    at clojure.lang.Compiler.eval(Compiler.java:7051)
    at clojure.lang.Compiler.load(Compiler.java:7514)
    ... 12 more
Subprocess failed

    *
```